### PR TITLE
fix: improve mobile responsiveness and modal spacing

### DIFF
--- a/app/invoice/[token]/error.tsx
+++ b/app/invoice/[token]/error.tsx
@@ -10,7 +10,7 @@ interface ErrorPageProps {
 
 export default function Error({ error, reset }: ErrorPageProps) {
   return (
-    <div className="min-h-screen relative pb-20 md:pb-0">
+    <div className="min-h-[100dvh] relative pb-20 md:pb-0">
       {/* Background Image */}
       <div
         className="absolute inset-0 bg-cover bg-center bg-no-repeat"
@@ -20,7 +20,7 @@ export default function Error({ error, reset }: ErrorPageProps) {
       />
 
       {/* Error Card */}
-      <div className="relative z-10 flex items-center justify-center min-h-screen p-4">
+      <div className="relative z-10 flex items-center min-h-[100dvh] p-4">
         <div className="w-full max-w-4xl mx-auto p-6 rounded-2xl bg-white/10 backdrop-blur-md border border-white/20 shadow-xl">
           <div className="text-center space-y-6">
             <div className="flex justify-center">

--- a/app/invoice/[token]/loading.tsx
+++ b/app/invoice/[token]/loading.tsx
@@ -1,6 +1,6 @@
 export default function Loading() {
   return (
-    <div className="min-h-screen relative pb-20 md:pb-0">
+    <div className="min-h-[100dvh] relative pb-20 md:pb-0">
       {/* Background Image */}
       <div
         className="absolute inset-0 bg-cover bg-center bg-no-repeat"
@@ -10,7 +10,7 @@ export default function Loading() {
       />
 
       {/* Loading Skeleton */}
-      <div className="relative z-10 flex items-center justify-center min-h-screen p-4">
+      <div className="relative z-10 flex items-center min-h-[100dvh] p-4">
         <div className="w-full max-w-4xl mx-auto p-6 rounded-2xl bg-white/10 backdrop-blur-md border border-white/20 shadow-xl">
           <div className="space-y-6">
             {/* Header Skeleton */}

--- a/app/invoice/[token]/page.tsx
+++ b/app/invoice/[token]/page.tsx
@@ -132,12 +132,12 @@ export default async function InvoicePage({ params, searchParams }: InvoicePageP
   const paymentStatus = searchParams?.payment;
 
   return (
-    <div className="min-h-screen overflow-hidden relative">
+    <div className="min-h-[100dvh] overflow-x-hidden relative">
       <div
         className="fixed inset-0 bg-cover bg-center bg-no-repeat"
         style={{ backgroundImage: "url(/Grid%202.png)" }}
       />
-      <div className="relative z-10 flex flex-col items-center justify-center min-h-screen py-8 px-4 space-y-4">
+      <div className="relative z-10 flex flex-col items-center min-h-[100dvh] px-4 pt-8 pb-24 md:pb-8 space-y-4">
         {paymentStatus === 'success' && (
           <div
             role="alert"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,12 +8,12 @@ export default function HomePage() {
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
   const [message, setMessage] = useState('');
   return (
-    <div className="min-h-screen overflow-hidden relative">
+    <div className="min-h-[100dvh] overflow-x-hidden relative">
       <div
         className="fixed inset-0 bg-cover bg-center bg-no-repeat"
         style={{ backgroundImage: "url(/Grid%202.png)" }}
       />
-      <div className="relative z-10 flex flex-col items-center justify-center min-h-screen py-8 px-4 space-y-6">
+      <div className="relative z-10 flex flex-col items-center min-h-[100dvh] py-8 px-4 space-y-6">
         {status === 'idle' && (
           <div className="w-full max-w-2xl mx-auto p-8 rounded-2xl bg-gradient-to-b from-white/20 to-white/10 backdrop-blur-md border border-white/20 shadow-[0_8px_32px_rgba(0,0,0,0.12)] hover:shadow-[0_8px_32px_rgba(0,0,0,0.2)] transition-all duration-300">
             <div className="flex flex-col items-center space-y-6">

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -16,7 +16,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "fixed top-0 z-[100] flex max-h-[100dvh] w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
       className
     )}
     {...props}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -89,4 +89,10 @@
   body {
     @apply bg-background text-foreground;
   }
+  iframe[src*="helcim-pay"] {
+    margin-block: 5vh;
+    display: block;
+    margin-inline: auto;
+    max-height: 90vh;
+  }
 }


### PR DESCRIPTION
## Summary
- allow invoice and home pages to scroll naturally on mobile by using dynamic viewport heights and removing overflow restrictions
- ensure Helcim Pay modal has balanced top and bottom spacing
- update toast viewport and page containers to avoid dead zones on small screens

## Testing
- `pnpm lint` *(fails: Invalid Options: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_68c19b45d05c83339397b499a0b79996